### PR TITLE
add String() call to prevent recursion

### DIFF
--- a/choice.gotpl
+++ b/choice.gotpl
@@ -25,7 +25,7 @@ package {{.Package}}
     {{end}}
 
     {{if $member.Error}}
-        func ({{$member.ShortName}} {{$member.Name}}) Error() string { return fmt.Sprintf("%T: %v",{{$member.ShortName}},{{$member.ShortName}}) }
+        func ({{$member.ShortName}} {{$member.Name}}) Error() string { return fmt.Sprintf("%T: %v",{{$member.ShortName}},{{$member.ShortName}}.String()) }
     {{end}}
 {{end}}
 


### PR DESCRIPTION
If whatever is evaluated here by %v is not a string, String will be called recursively.
By adding the String() call we ensure that we will evaluate a string and prevent recursion with the drawback, that we have to implement a Stringer interface on any error we want to generate.